### PR TITLE
Support for RX IRQ

### DIFF
--- a/drivers/usb_c/tcpc/fusb302b.c
+++ b/drivers/usb_c/tcpc/fusb302b.c
@@ -19,10 +19,16 @@ static const uint8_t REG_MEASURE = 0x04;
 static const uint8_t REG_CONTROL0 = 0x06;
 static const uint8_t REG_CONTROL1 = 0x07;
 static const uint8_t REG_CONTROL3 = 0x09;
+static const uint8_t REG_MASK = 0x0a;
 static const uint8_t REG_POWER = 0x0b;
 static const uint8_t REG_RESET = 0x0c;
+static const uint8_t REG_MASKA = 0x0e;
+static const uint8_t REG_MASKB = 0x0f;
+static const uint8_t REG_INTERRUPTA = 0x3e;
+static const uint8_t REG_INTERRUPTB = 0x3f;
 static const uint8_t REG_STATUS0 = 0x40;
 static const uint8_t REG_STATUS1 = 0x41;
+static const uint8_t REG_INTERRUPT = 0x42;
 static const uint8_t REG_FIFO = 0x43;
 
 static const uint8_t TX_TOKEN_TXON = 0xA1;
@@ -269,9 +275,83 @@ int fusb302_setup(const struct device *dev) {
 	return 0;
 }
 
+
+static void fusb302b_irq_work(struct k_work *work)
+{
+	struct fusb302b_data *data = CONTAINER_OF(work, struct fusb302b_data, irq_work);
+	const struct fusb302b_cfg *cfg = data->dev->config;
+	uint8_t dummy;
+
+	int ret = i2c_reg_read_byte_dt(&cfg->i2c, REG_INTERRUPTB, &dummy);
+	if (ret < 0) {
+		LOG_ERR("Failure to clear IRQ: %d", ret);
+		return;
+	}
+
+	if (!dummy)
+		LOG_ERR("Spurious IRQ");
+}
+
+static void fusb302b_isr(const struct device *dev, struct gpio_callback *cb,
+			 uint32_t pins)
+{
+	ARG_UNUSED(pins);
+	LOG_DBG("IRQ");
+	struct fusb302b_data *data =
+		CONTAINER_OF(cb, struct fusb302b_data, gpio_cb);
+
+	atomic_set(&data->data_avail, 1);
+	data->alert_info.handler(data->dev, data->alert_info.data, TCPC_ALERT_MSG_STATUS);
+
+	k_work_submit(&data->irq_work);
+}
+
+static int fusb302b_config_irq(const struct device *dev)
+{
+	const struct fusb302b_cfg *cfg = dev->config;
+	struct fusb302b_data *data = dev->data;
+	uint8_t dummy;
+	int ret;
+
+	if (!gpio_is_ready_dt(&cfg->gpio_irq)) {
+		LOG_ERR("gpio IRQ not ready");
+		return -ENODEV;
+	}
+
+	data->irq_work.handler = fusb302b_irq_work;
+	gpio_pin_configure_dt(&cfg->gpio_irq, GPIO_INPUT);
+	gpio_init_callback(&data->gpio_cb, fusb302b_isr, BIT(cfg->gpio_irq.pin));
+	ret = gpio_add_callback(cfg->gpio_irq.port, &data->gpio_cb);
+
+	if (ret < 0) {
+		LOG_ERR("Failed to set gpio callback");
+		return ret;
+	}
+
+	LOG_INF("Enabling RX interrupt");
+	ret = i2c_reg_write_byte_dt(&cfg->i2c, REG_MASK, 0xff);
+	if (ret != 0) { return -EIO; }
+	ret = i2c_reg_write_byte_dt(&cfg->i2c, REG_MASKA, 0xff);
+	if (ret != 0) { return -EIO; }
+
+	ret = i2c_reg_read_byte_dt(&cfg->i2c, REG_INTERRUPT, &dummy);
+	if (ret != 0) { return -EIO; }
+	ret = i2c_reg_read_byte_dt(&cfg->i2c, REG_INTERRUPTA, &dummy);
+	if (ret != 0) { return -EIO; }
+	ret = i2c_reg_read_byte_dt(&cfg->i2c, REG_INTERRUPTB, &dummy);
+	if (ret != 0) { return -EIO; }
+
+	ret = gpio_pin_interrupt_configure_dt(&cfg->gpio_irq, GPIO_INT_EDGE_TO_ACTIVE);
+	if (ret != 0) { return -EIO; }
+
+	return i2c_reg_write_byte_dt(&cfg->i2c, REG_MASKB, 0);
+}
+
 int fusb302b_init(const struct device *dev) {
 	LOG_INF("Init");
 	const struct fusb302b_cfg *cfg = dev->config;
+	struct fusb302b_data *data = dev->data;
+	data->dev = dev;
 
 	if (!i2c_is_ready_dt(&cfg->i2c)) {
 		LOG_ERR("I2C driver not ready");
@@ -289,25 +369,29 @@ int fusb302b_init(const struct device *dev) {
 		return -EIO;
 	}
 
-	int res = 0;
-
 	/* Power up all parts of device */
 	LOG_INF("Power up");
-	res = i2c_reg_write_byte_dt(&cfg->i2c, REG_POWER, 0b00001111);
-	if (res != 0) {
+	ret = i2c_reg_write_byte_dt(&cfg->i2c, REG_POWER, 0b00001111);
+	if (ret != 0) {
 		LOG_ERR("Error during powerup");
 		return -EIO;
 	}
 
-	/* Unmask interrupts */
-	LOG_INF("Enabling interrupts");
-	res = i2c_reg_write_byte_dt(&cfg->i2c, REG_CONTROL0, 0b00000000);
-	if (res != 0) { return -EIO; }
+	data->data_avail = ATOMIC_INIT(0);
+	ret = fusb302b_config_irq(dev);
+	if (ret < 0) {
+		LOG_ERR("Failed to enable interrupt");
+		return ret;
+	}
+	if (ret != 0) { return -EIO; }
+
+	ret = i2c_reg_write_byte_dt(&cfg->i2c, REG_CONTROL0, 0b00000000);
+	if (ret != 0) { return -EIO; }
 
 	/* Enable packet retries */
 	LOG_INF("Enabling retries");
-	res = i2c_reg_write_byte_dt(&cfg->i2c, REG_CONTROL3, 0b00000111);
-	if (res != 0) { return -EIO; }
+	ret = i2c_reg_write_byte_dt(&cfg->i2c, REG_CONTROL3, 0b00000111);
+	if (ret != 0) { return -EIO; }
 
 	LOG_INF("Init done");
 	return 0;
@@ -430,11 +514,17 @@ static int fusb302b_get_rx_pending_msg(const struct device *dev, struct pd_msg *
 	int res = 0;
 	uint8_t status1;
 
+	if (!atomic_get(&data->data_avail))
+		return -ENODATA;
+
 	res = i2c_reg_read_byte_dt(&cfg->i2c, REG_STATUS1, &status1);
 	if (res != 0) { return -EIO; }
 	bool rx_empty = (status1 & 0b100000) != 0;
 
-	if (rx_empty) { return -ENODATA; }
+	if (rx_empty) {
+		atomic_set(&data->data_avail, 0);
+		return -ENODATA;
+	};
 
 	if (buf == NULL) {
 		// Message is pending and buf parameter is NULL
@@ -644,13 +734,16 @@ static const struct tcpc_driver_api fusb302b_tcpc_driver_api = {
 		.set_alert_handler_cb = fusb302b_set_alert_handler_cb,
 };
 
-#define FUSB302B_DEFINE(inst)                                                                                          \
-	static struct fusb302b_data fusb302b_data_##inst = {0};                                                            \
-	static const struct fusb302b_cfg fusb302b_config_##inst = {                                                        \
-			.i2c = I2C_DT_SPEC_INST_GET(inst),                                                                         \
-	};                                                                                                                 \
-	DEVICE_DT_INST_DEFINE(inst, fusb302b_init, /* pm_device = */ NULL, &fusb302b_data_##inst, &fusb302b_config_##inst, \
-						  /* level = */ POST_KERNEL, CONFIG_USBC_TCPC_INIT_PRIORITY, &fusb302b_tcpc_driver_api);
+#define FUSB302B_DEFINE(inst)                                                            \
+	static struct fusb302b_data fusb302b_data_##inst = {0};                          \
+	static const struct fusb302b_cfg fusb302b_config_##inst = {                      \
+			.i2c = I2C_DT_SPEC_INST_GET(inst),                               \
+			.gpio_irq = GPIO_DT_SPEC_INST_GET(inst, int_gpios),      \
+	};                                                                               \
+	DEVICE_DT_INST_DEFINE(inst, fusb302b_init, /* pm_device = */                     \
+			      NULL, &fusb302b_data_##inst, &fusb302b_config_##inst,      \
+			      /* level = */ POST_KERNEL, CONFIG_USBC_TCPC_INIT_PRIORITY, \
+		              &fusb302b_tcpc_driver_api);
 
 BUILD_ASSERT(DT_NUM_INST_STATUS_OKAY(DT_DRV_COMPAT) > 0, "No compatible FUSB302B instance found");
 

--- a/drivers/usb_c/tcpc/fusb302b.c
+++ b/drivers/usb_c/tcpc/fusb302b.c
@@ -596,7 +596,7 @@ int fusb302b_transmit_data(const struct device *dev, struct pd_msg *msg) {
 			res = transmit_hard_reset(cfg);
 			break;
 		default:
-			LOG_ERR("Packet type %s not supported", pd_packet_type_to_str(msg->type));
+			LOG_ERR("Packet type not supported");
 			res = -1;
 			break;
 	}

--- a/drivers/usb_c/tcpc/fusb302b_private.h
+++ b/drivers/usb_c/tcpc/fusb302b_private.h
@@ -9,6 +9,7 @@
 #include <zephyr/drivers/i2c.h>
 #include <zephyr/drivers/usb_c/usbc_tcpc.h>
 #include <zephyr/drivers/gpio.h>
+#include <zephyr/kernel.h>
 
 #define FUSB302_RX_BUFFER_SIZE 80
 
@@ -18,12 +19,17 @@ struct alert_info {
 };
 
 struct fusb302b_data {
+	const struct device *dev;
 	struct alert_info alert_info;
+	struct gpio_callback gpio_cb;
+	struct k_work irq_work;
 	int cc;
+	atomic_t data_avail;
 };
 
 struct fusb302b_cfg {
 	struct i2c_dt_spec i2c;
+	struct gpio_dt_spec gpio_irq;
 };
 
 int fusb302b_init(const struct device *dev);

--- a/dts/bindings/usb-c/fcs,fusb302b.yml
+++ b/dts/bindings/usb-c/fcs,fusb302b.yml
@@ -6,3 +6,11 @@ description: FUSB302B Programmable USB Type-C Controller with PD
 compatible: "fcs,fusb302b"
 
 include: i2c-device.yaml
+
+properties:
+  int-gpios:
+    type: phandle-array
+    description: |
+      The INT signal default configuration is active-high.  The
+      property value should ensure the flags properly describe the
+      signal that is presented to the driver.


### PR DESCRIPTION
Add support for RX IRQ. This is useful because of two reasons:

-  Avoid most useless I2C transactions (due to blind RX polling).
-  Shortened (and hopefully independent by USB-C stack thread polling rate) delay to respond to messages. Note that  the source (at least mine) sends a hardware resets messages and it removes the power if it doesn't receive any request messages after ~25ms since any acknowledged capability advertisement, so extra delay is harmful here..

BTW  The USB-C stack still continues to periodically polling for pending messages, but with this patch the handler is often able to return -ENODATA without waste an I2C transaction (I wonder whether there is some method to tell the USB-C stack not to poll at all since we support interrupts..).

Probably we may want to make the IRQ support *optional* while this patch doesn't care about that, but I wanted to share this early.

This PR indeed contains also another small commit that fixed a compile error due to missing function (logging-related).
